### PR TITLE
NO-TICKET Fix test

### DIFF
--- a/src/test/java/de/wejago/hichi2influx/service/MqttSubscriberServiceTest.java
+++ b/src/test/java/de/wejago/hichi2influx/service/MqttSubscriberServiceTest.java
@@ -66,8 +66,7 @@ class MqttSubscriberServiceTest {
         // THEN
         verify(mqttClient, times(1)).connect(mqttConnectOptions);
         assertThatThrownBy(() -> { throw new MqttException(1); })
-            .isInstanceOf(MqttException.class)
-            .hasMessage("Invalid protocol version");
+            .isInstanceOf(MqttException.class);
         assertThat(output.getOut()).contains("Error connecting to MQTT client!");
     }
 }


### PR DESCRIPTION
Remove message check because the error message is not system independent