### PR TITLE
NO-TICKET Remove backup from same day

### DIFF
--- a/scripts/backup_influx.sh
+++ b/scripts/backup_influx.sh
@@ -47,6 +47,8 @@ CURRENT_DATE=$(date +'%Y-%m-%d')
 IFS=' ' read -r -a CONTAINER <<< "$INFLUX_LINE"
 
 # shellcheck disable=SC2128
+docker exec -it "$CONTAINER" rm -rf $CURRENT_DATE
+# shellcheck disable=SC2128
 docker exec -it "$CONTAINER" influx backup $CURRENT_DATE -t $INFLUX_TOKEN
 # shellcheck disable=SC2128
 docker cp $CONTAINER:$CURRENT_DATE $b


### PR DESCRIPTION
This fix removes backup data created same day in the influx container, e.g. if you create a backup at 3pm and then you create another one at 5pm, the backup data from 3 pm will be removed before creating the new backup